### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,27 +1,24 @@
-# Default owner for anything not listed below
-*                       @ibhati
-
 # C/C++ library code
-/include/               @ibhati @aaron-dl-lin
-/cmake/                 @ibhati
-/tests/                 @aaron-dl-lin @ibhati
-/benchmark/             @ibhati
-/tools/                 @ibhati
-/utils/                 @ibhati
+/include/               @ibhati @aaron-dl-lin @Alexsandruss @ahuber21
+/cmake/                 @mihaic @ibhati @aaron-dl-lin @Alexsandruss @ahuber21 
+/tests/                 @mihaic @ibhati @aaron-dl-lin @Alexsandruss @ahuber21 @yuejiaointel 
+/benchmark/             @mihaic @ibhati @aaron-dl-lin @Alexsandruss @ahuber21 
+/tools/                 @mihaic @ibhati @aaron-dl-lin @Alexsandruss @ahuber21 
+/utils/                 @mihaic @ibhati @aaron-dl-lin @Alexsandruss @ahuber21 
 
 # Python and other language bindings
-/bindings/              @ethanglaser
+/bindings/              @ethanglaser @ibhati @aaron-dl-lin @Alexsandruss @ahuber21
 
 # Examples and datasets
-/examples/              @ibhati @aaron-dl-lin
-/data/                  @ibhati
+/examples/              @ibhati @aaron-dl-lin @ahuber21
+/data/                  @ibhati @ahuber21
 
 # Docker and build environment
-/docker/                @mihaic
+/docker/                @mihaic @ahuber21 
+
+# CI and infra
+/.github                @mihaic @homksei @yuejiaointel
 
 # Documentation and meta files
-/README.md              @aguerreb @napetrov
-/HISTORY.md             @aguerreb @napetrov
-/SECURITY.md            @aguerreb @napetrov
-/NEWS.md                @aguerreb @napetrov
+/*.md                   @aguerreb @napetrov
 /THIRD-PARTY-PROGRAMS   @aguerreb @napetrov

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # C/C++ library code
-/include/               @ibhati @aaron-dl-lin @Alexsandruss @ahuber21
+/include/               @ibhati @dian-lun-lin @Alexsandruss @ahuber21
 /cmake/                 @mihaic @ibhati @aaron-dl-lin @Alexsandruss @ahuber21 
 /tests/                 @mihaic @ibhati @aaron-dl-lin @Alexsandruss @ahuber21 @yuejiaointel 
 /benchmark/             @mihaic @ibhati @aaron-dl-lin @Alexsandruss @ahuber21 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,27 @@
+# Default owner for anything not listed below
+*                       @ibhati
+
+# C/C++ library code
+/include/               @ibhati @aaron-dl-lin
+/cmake/                 @ibhati
+/tests/                 @aaron-dl-lin @ibhati
+/benchmark/             @ibhati
+/tools/                 @ibhati
+/utils/                 @ibhati
+
+# Python and other language bindings
+/bindings/              @ethanglaser
+
+# Examples and datasets
+/examples/              @ibhati @aaron-dl-lin
+/data/                  @ibhati
+
+# Docker and build environment
+/docker/                @mihaic
+
+# Documentation and meta files
+/README.md              @aguerreb @napetrov
+/HISTORY.md             @aguerreb @napetrov
+/SECURITY.md            @aguerreb @napetrov
+/NEWS.md                @aguerreb @napetrov
+/THIRD-PARTY-PROGRAMS   @aguerreb @napetrov

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,16 +1,16 @@
 # C/C++ library code
 /include/               @ibhati @dian-lun-lin @Alexsandruss @ahuber21
-/cmake/                 @mihaic @ibhati @aaron-dl-lin @Alexsandruss @ahuber21 
-/tests/                 @mihaic @ibhati @aaron-dl-lin @Alexsandruss @ahuber21 @yuejiaointel 
-/benchmark/             @mihaic @ibhati @aaron-dl-lin @Alexsandruss @ahuber21 
-/tools/                 @mihaic @ibhati @aaron-dl-lin @Alexsandruss @ahuber21 
-/utils/                 @mihaic @ibhati @aaron-dl-lin @Alexsandruss @ahuber21 
+/cmake/                 @mihaic @ibhati @dian-lun-lin @Alexsandruss @ahuber21 
+/tests/                 @mihaic @ibhati @dian-lun-lin @Alexsandruss @ahuber21 @yuejiaointel 
+/benchmark/             @mihaic @ibhati @dian-lun-lin @Alexsandruss @ahuber21 
+/tools/                 @mihaic @ibhati @dian-lun-lin @Alexsandruss @ahuber21 
+/utils/                 @mihaic @ibhati @dian-lun-lin @Alexsandruss @ahuber21 
 
 # Python and other language bindings
-/bindings/              @ethanglaser @ibhati @aaron-dl-lin @Alexsandruss @ahuber21
+/bindings/              @ethanglaser @ibhati @dian-lun-lin @Alexsandruss @ahuber21
 
 # Examples and datasets
-/examples/              @ibhati @aaron-dl-lin @ahuber21
+/examples/              @ibhati @dian-lun-lin @ahuber21
 /data/                  @ibhati @ahuber21
 
 # Docker and build environment

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,7 +17,7 @@
 /docker/                @mihaic @ahuber21 
 
 # CI and infra
-/.github                @mihaic @homksei @yuejiaointel
+/.github                @mihaic @homksei @yuejiaointel @ethanglaser
 
 # Documentation and meta files
 /*.md                   @aguerreb @napetrov


### PR DESCRIPTION
## Summary
- define project ownership for each part of the repo

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'svs')*
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_684cc9d74f9c832bbefd6b511445f31e

## Summary by Sourcery

New Features:
- Add .github/CODEOWNERS file to define code ownership for repository paths